### PR TITLE
feature/#9 Mac-a-thon Subdomain URL redirect

### DIFF
--- a/apps/mac-a-thon/app/__tests__/next.confg.test.tsx
+++ b/apps/mac-a-thon/app/__tests__/next.confg.test.tsx
@@ -1,0 +1,28 @@
+// next.config.test.js
+import type { NextConfig } from 'next'
+import nextConfig from '../../next.config.mjs'
+
+const config = nextConfig as NextConfig
+
+describe('Next.js Redirects', () => {
+  it('should define a redirects function', () => {
+    expect(typeof nextConfig.redirects).toBe('function')
+  })
+
+  it('should redirect mac-a-thon.gdscmcmasteru.ca to gdgmcmasteru.ca', async () => {
+    const redirects = await config.redirects?.()
+    expect(redirects).toBeDefined()
+
+    const rule = redirects?.find(
+      (r) => r.has?.[0]?.value === 'mac-a-thon.gdscmcmasteru.ca',
+    )
+    expect(rule).toBeDefined()
+    expect(rule?.source).toBe('/:path*')
+    expect(rule?.destination).toBe('https://mac-a-thon.gdgmcmasteru.ca/:path*')
+    expect(rule?.permanent).toBe(true)
+  })
+
+  it('should allow images from cdn.sanity.io', () => {
+    expect(nextConfig.images?.domains).toContain('cdn.sanity.io')
+  })
+})

--- a/apps/mac-a-thon/next.config.mjs
+++ b/apps/mac-a-thon/next.config.mjs
@@ -5,6 +5,24 @@ const nextConfig = {
             'cdn.sanity.io',
         ]
     },
+    redirects: async () => {
+    return [
+      {
+        source: '/:path*',
+        has: [
+          {
+            type: 'host',
+            value: 'mac-a-thon.gdscmcmasteru.ca',
+          },
+        ],
+        destination: 'https://mac-a-thon.gdgmcmasteru.ca/:path*',
+        permanent: true,
+      },
+    ];
+  },
 };
+
+    
+
 
 export default nextConfig;


### PR DESCRIPTION
Added redirect to next.config to redirect from old gdscmcmasteru.ca to  gdgmcmasteru.ca for the mac-a-thon subdomain. 

Testing:
- Verified redirect rules are defined in config.
- Confirmed redirect works as expected.
- Ensured redirect is marked as permanent (301).

Ticket: 
https://github.com/DSC-McMaster-U/marketing/issues/9 
